### PR TITLE
Add eye extractor abstractions for dlib and single-eye processing

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -3,9 +3,8 @@ from queue import Queue
 import time
 
 from blink_data_exporter import BlinkDataExporter
-from eye_detector import EyeDetector
 from frame_info import FrameInfo, EyeData, Eye
-from frame_processor import FrameProcessor
+from eye_extractor import DlibEyeExtractor
 from video_recorder import VideoRecorder
 from blink_predictor import BlinkPredictor
 from frame_source import FrameSource
@@ -20,8 +19,7 @@ class EyeDetectionController:
         self.cameras = WebcamCapture.get_available_cameras(5)
         self.frame_source = frame_source
         self.frame_queue = Queue()
-        self.eye_detector = EyeDetector()
-        self.frame_processor = FrameProcessor()
+        self.eye_extractor = DlibEyeExtractor()
         self.blink_predictor = BlinkPredictor(self.frame_source)
         self.video_recorder = VideoRecorder(self.frame_source, self.blink_predictor)
         self.frame_count = 0
@@ -103,9 +101,9 @@ class EyeDetectionController:
             frame_width = self.frame_source.get_frame_width()
             frame_height = self.frame_source.get_frame_height()
 
-            eye_boxes = self.eye_detector.calculate_eye_boxes(frame)
-            frame_with_boxes = self.frame_processor.visualize_eye_boxes(frame, eye_boxes)
-            left_eye_images, right_eye_images = self.frame_processor.extract_eye_images(frame, eye_boxes)
+            left_eye_images, right_eye_images, frame_with_boxes, eye_boxes = (
+                self.eye_extractor.extract(frame)
+            )
 
             eyes: dict[Eye, EyeData] = {}
             if len(left_eye_images) > 0:

--- a/eye_extractor.py
+++ b/eye_extractor.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Protocol
+import numpy as np
+from PIL import Image
+import cv2
+
+from eye_detector import EyeDetector
+from frame_processor import FrameProcessor
+
+
+class EyeExtractor(Protocol):
+    """Protocol for eye extractors."""
+
+    def extract(
+        self, frame: np.ndarray
+    ) -> tuple[list[Image.Image], list[Image.Image], Image.Image, list]:
+        """Extract eyes from a frame."""
+        ...
+
+
+class DlibEyeExtractor:
+    """Extractor that uses dlib to detect eyes in a frame."""
+
+    def __init__(self) -> None:
+        self.eye_detector = EyeDetector()
+        self.frame_processor = FrameProcessor()
+
+    def extract(
+        self, frame: np.ndarray
+    ) -> tuple[list[Image.Image], list[Image.Image], Image.Image, list]:
+        eye_boxes = self.eye_detector.calculate_eye_boxes(frame)
+        frame_with_boxes = self.frame_processor.visualize_eye_boxes(frame, eye_boxes)
+        left_eye_images, right_eye_images = self.frame_processor.extract_eye_images(
+            frame, eye_boxes
+        )
+        return left_eye_images, right_eye_images, frame_with_boxes, eye_boxes
+
+
+class SingleEyeExtractor:
+    """Extractor that treats the whole frame as a single eye."""
+
+    def __init__(self, eye: str) -> None:
+        if eye not in ("left", "right"):
+            raise ValueError("eye must be 'left' or 'right'")
+        self.eye = eye
+
+    def extract(
+        self, frame: np.ndarray
+    ) -> tuple[list[Image.Image], list[Image.Image], Image.Image, list]:
+        eye_img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        left_eye_images = [eye_img] if self.eye == "left" else []
+        right_eye_images = [eye_img] if self.eye == "right" else []
+        return left_eye_images, right_eye_images, eye_img, []


### PR DESCRIPTION
## Summary
- Introduce `eye_extractor` module with `EyeExtractor` protocol
- Implement `DlibEyeExtractor` using existing detection logic
- Add `SingleEyeExtractor` for pre-cropped eye frames
- Refactor controller to use extractor abstraction

## Testing
- `python -m py_compile eye_extractor.py controller.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae130ce09c83268be505a4dc23f96e